### PR TITLE
Add the ability to select the file format (CSV or XLSX) in the export form

### DIFF
--- a/app/views/active_scaffold_overrides/_export_form_body.html.erb
+++ b/app/views/active_scaffold_overrides/_export_form_body.html.erb
@@ -1,9 +1,14 @@
 <% export_config = active_scaffold_config.export %>
 <h3><%=as_(:columns_for_export)%></h3>
+<% if ActiveScaffold.js_framework == :jquery %>
+<%= link_to_function 'Select All',  'jQuery(".columnCheckbox").prop("checked", true);',  :class => 'active-scaffold-footer' %>
+&nbsp;&nbsp;
+<%= link_to_function 'Select None', 'jQuery(".columnCheckbox").prop("checked", false);', :class => 'active-scaffold-footer' %>
+<% end %>
 <div class="columns checkbox-list">
 <% export_config.columns.each do |column| -%>
   <div class="column checkbox-wrapper">
-    <%= content_tag(:label, check_box_tag("export_columns[#{column.name}]", 1, !export_config.default_deselected_columns.include?(column.name)) + "&nbsp;#{column.label}".html_safe) %>
+    <%= content_tag(:label, check_box_tag("export_columns[#{column.name}]", 1, !export_config.default_deselected_columns.include?(column.name), :class => 'columnCheckbox') + "&nbsp;#{column.label}".html_safe) %>
   </div>
 <% end -%>
 &nbsp;
@@ -23,6 +28,13 @@
   </div>
   <div class="option checkbox-wrapper">
     <%= content_tag(:label, radio_button_tag('full_download', true, export_config.default_full_download) + " #{as_(:all_pages)}".html_safe) if export_config.allow_full_download %>
+  </div>
+  <div class="separator"></div>
+  <div class="option checkbox-wrapper">
+    <%= content_tag(:label, radio_button_tag('format', :xlsx, export_config.default_file_format.to_sym == :xlsx) + ' XLSX') %>
+  </div>
+  <div class="option checkbox-wrapper">
+    <%= content_tag(:label, radio_button_tag('format', :csv, export_config.default_file_format.to_sym == :csv) + ' CSV') %>
   </div>
   &nbsp;
 </div>

--- a/app/views/active_scaffold_overrides/_show_export.html.erb
+++ b/app/views/active_scaffold_overrides/_show_export.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => "base_form", :locals => {:xhr => false,
                                                 :form_action => :export,
-                                                :url_options => params_for(:action => :export, :format => @export_config.default_file_format),
+                                                :url_options => params_for(:action => :export),
                                                 :method => :post,
                                                 :cancel_link => true,
                                                 :headline => as_(:export),

--- a/lib/active_scaffold/actions/export.rb
+++ b/lib/active_scaffold/actions/export.rb
@@ -125,7 +125,19 @@ module ActiveScaffold::Actions
     # The default name of the downloaded file.
     # You may override the method to specify your own file name generation.
     def export_file_name
-      "#{self.controller_name}.#{active_scaffold_config.export.default_file_format}"
+      filename = self.controller_name
+
+      if params[:format]
+        if params[:format].to_sym == :xlsx
+          filename << '.xlsx'
+        elsif params[:format].to_sym == :csv
+          filename << '.csv'
+        end
+      else
+        filename << ".#{active_scaffold_config.export.default_file_format}"
+      end
+
+      return filename
     end
 
     # The default security delegates to ActiveRecordPermissions.


### PR DESCRIPTION
Heres the modifications I was talking about in the Google group. 

I also added a "Select All" and "Select None" links to the export form to select all or no column checkboxes when using jquery.

Feel free to clean it up or make improvements.
