### PR TITLE
Search the database before start streaming data

### DIFF
--- a/lib/active_scaffold/actions/export.rb
+++ b/lib/active_scaffold/actions/export.rb
@@ -66,16 +66,18 @@ module ActiveScaffold::Actions
         format.csv do
           response.headers['Content-type'] = 'text/csv'
           # start streaming output
+          @output = ""
+          find_items_for_export do |records|
+            @records = records
+            str = render_to_string :partial => 'export', :layout => false, :formats => [:csv]
+            @output << str
+            params[:skip_header] = 'true' # skip header on the next run
+          end
           self.response_body = Enumerator.new do |y|
-            find_items_for_export do |records|
-              @records = records
-              str = render_to_string :partial => 'export', :layout => false, :formats => [:csv]
-              y << str
-              params[:skip_header] = 'true' # skip header on the next run
-            end
+            y << @output
           end
         end
-        format.xlsx do 
+        format.xlsx do
           response.headers['Content-type'] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
           p = Axlsx::Package.new
           header = p.workbook.styles.add_style sz: 11, b: true,:bg_color => "69B5EF", :fg_color => "FF", alignment: { horizontal: :center }
@@ -89,7 +91,7 @@ module ActiveScaffold::Actions
           end
           stream = p.to_stream # when adding rows to sheet, they won't pass to this stream if declared before. axlsx issue?
           self.response_body = Enumerator.new do |y|
-            y << stream.read 
+            y << stream.read
           end
         end
 


### PR DESCRIPTION
Sorting out a problem with exporting while streaming. As we have a multi-shard app, when we start streaming in the gem we would return an empty body and will do the query in a background process, that unfortunately doesn't call our middlewares, in particular the one that sets the shard. This PR amends the way the gem works, retrieving the data before start streaming, in order to don't have problem with the shard anymore.
