### PR TITLE
Disables loading indicator and form disabling on export

### DIFF
--- a/app/views/active_scaffold_overrides/_show_export.html.erb
+++ b/app/views/active_scaffold_overrides/_show_export.html.erb
@@ -4,4 +4,5 @@
                                                 :method => :post,
                                                 :cancel_link => true,
                                                 :headline => as_(:export),
-                                                :body_partial => 'export_form_body'} %>
+                                                :body_partial => 'export_form_body',
+                                                :loading => false} %>


### PR DESCRIPTION
Prevents the form from becoming disabled and the loading indicator from showing up, since they will not be cleared when export has completed.

This is dependent on a release of active_scaffold including this PR: https://github.com/activescaffold/active_scaffold/pull/535